### PR TITLE
don't load recaptcha when offline

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "re-captcha",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "keywords": [
     "recaptcha",
     "polymer",
@@ -9,18 +9,23 @@
   ],
   "main": "re-captcha.html",
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.4.0"
+    "polymer": "Polymer/polymer#^1.4.0",
+    "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^1.0.5"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
     "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
     "web-component-tester": "^4.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
+    "paper-card": "PolymerElements/paper-card#^1.1.4",
+    "iron-form": "PolymerElements/iron-form#^1.1.4",
+    "paper-input": "PolymerElements/paper-input#^1.1.23"
   },
   "homepage": "https://github.com/cbalit/re-captcha",
   "authors": [
-    "Cyril Balit <cbalit@gmail.com>"
+    "Cyril Balit <cbalit@gmail.com>",
+    "Tobi Seitz <tobi@tobitobi.de>"
   ],
   "description": "A Polymer reCaptcha component",
   "license": "MIT",

--- a/re-captcha.html
+++ b/re-captcha.html
@@ -197,10 +197,10 @@ BEWARE: THE re-captcha ELEMENT ONLY WORKS IN THE DOM OR LIGHT DOM OF ANOTHER COM
         //Remove script
         this._removeScriptApiTag();
         //remove container
-        if(this.inbody){
+        if (this.inbody) {
           document.body.removeChild(this._container);
         }
-        else{
+        else {
           Polymer.dom(this).removeChild(this._container);
         }
         this._container = null;
@@ -234,19 +234,30 @@ BEWARE: THE re-captcha ELEMENT ONLY WORKS IN THE DOM OR LIGHT DOM OF ANOTHER COM
       _generateScriptApiTag: function () {
         var head = document.getElementsByTagName('head')[0];
         var script = document.createElement('script');
-        script.setAttribute('async', '');
-        script.setAttribute('id', 'captcha');
-        script.setAttribute('defer', '');
-        script.setAttribute('type', 'text/javascript');
-        script.setAttribute('src', this._API_URL);
-        if (!this.lang) {
+
+        // let's prevent loading the script if the browser is offline
+        if ('navigator' in window && 'onLine' in window.navigator && window.navigator.onLine) {
+          script.setAttribute('async', '');
+          script.setAttribute('id', 'captcha');
+          script.setAttribute('defer', '');
+          script.setAttribute('type', 'text/javascript');
           script.setAttribute('src', this._API_URL);
+          if (!this.lang) {
+            script.setAttribute('src', this._API_URL);
+          }
+          else {
+            script.setAttribute('src', this._API_URL + '?hl=' + this.lang);
+          }
+          head.appendChild(script);
+          SCRIPT_LOADED = true;
+        } else {
+          console.warn('recaptcha not loaded because browser appears to be offline');
+          window.addEventListener('online', function () {
+            if (!SCRIPT_LOADED) {
+              this._generateScriptApiTag();
+            }
+          }.bind(this));
         }
-        else {
-          script.setAttribute('src', this._API_URL + '?hl=' + this.lang);
-        }
-        head.appendChild(script);
-        SCRIPT_LOADED = true;
       },
       attached: function () {
         if (this.sitekey === '') {
@@ -264,10 +275,10 @@ BEWARE: THE re-captcha ELEMENT ONLY WORKS IN THE DOM OR LIGHT DOM OF ANOTHER COM
       _generateContainer: function () {
         if (this._container === null) {
           this._container = document.createElement('div');
-          if(this.inbody){
+          if (this.inbody) {
             document.body.appendChild(this._container);
           }
-          else{
+          else {
             Polymer.dom(this).appendChild(this._container);
           }
         }
@@ -311,7 +322,7 @@ BEWARE: THE re-captcha ELEMENT ONLY WORKS IN THE DOM OR LIGHT DOM OF ANOTHER COM
           callback: this._responseHandler.bind(this),
           'expired-callback': this._expiredHandler.bind(this)
         });
-        if(this.inbody){
+        if (this.inbody) {
           this.fire('iron-resize');
         }
         this.fire('captcha-rendered', null);
@@ -352,7 +363,7 @@ BEWARE: THE re-captcha ELEMENT ONLY WORKS IN THE DOM OR LIGHT DOM OF ANOTHER COM
        */
       _responseHandler: function (response) {
         this.response = response;
-        this.fire('captcha-response', {response: response});
+        this.fire('captcha-response', { response: response });
       },
 
       /**
@@ -382,4 +393,5 @@ BEWARE: THE re-captcha ELEMENT ONLY WORKS IN THE DOM OR LIGHT DOM OF ANOTHER COM
     });
     return constructor;
   })();
+
 </script>


### PR DESCRIPTION
There were problems, when I used this component in a PWA. [Lighthouse](https://github.com/GoogleChrome/lighthouse) said the entire app returns a 404 because it tries to access the remote recaptcha script. So, to avoid this I check if the browser is online before creating the script tag. Additionally, an event listener takes care of loading the script when the browser goes back online.